### PR TITLE
Implement Search Stocks

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
 import UserDropdown from "./UserDropdown";
+import { searchStocks } from "@/lib/actions/finnhub.actions";
+import NavItems from "./NavItems";
 
-const Header = ({ user }: { user: User }) => {
+const Header = async ({ user }: { user: User }) => {
+  const initialStocks = await searchStocks();
   return (
     <header className="sticky top-0 header">
       <div className="container header-wrapper">
@@ -16,7 +19,7 @@ const Header = ({ user }: { user: User }) => {
           />
         </Link>
         <nav className="hidden sm:block">
-          {/* <NavItems initialStocks={initialStocks} /> */}
+          <NavItems initialStocks={initialStocks} />
         </nav>
 
         <UserDropdown user={user} initialStocks={[]} />

--- a/components/NavItems.tsx
+++ b/components/NavItems.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import React from "react";
+import SearchCommand from "./SearchCommand";
 
 const NavItems = ({
   initialStocks,
@@ -23,11 +24,11 @@ const NavItems = ({
         if (href === "/search")
           return (
             <li key="search-trigger">
-              {/* <SearchCommand
-                            renderAs="text"
-                            label="Search"
-                            initialStocks={initialStocks}
-                        /> */}
+              <SearchCommand
+                renderAs="text"
+                label="Search"
+                initialStocks={initialStocks}
+              />
             </li>
           );
 

--- a/components/SearchCommand.tsx
+++ b/components/SearchCommand.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { Loader2, TrendingUp } from "lucide-react";
+import Link from "next/link";
+import { searchStocks } from "@/lib/actions/finnhub.actions";
+import { useDebounce } from "@/hooks/useDebounce";
+
+export default function SearchCommand({
+  renderAs = "button",
+  label = "Add stock",
+  initialStocks,
+}: SearchCommandProps) {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [stocks, setStocks] =
+    useState<StockWithWatchlistStatus[]>(initialStocks);
+
+  const isSearchMode = !!searchTerm.trim();
+  const displayStocks = isSearchMode ? stocks : stocks?.slice(0, 10);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const handleSearch = async () => {
+    if (!isSearchMode) return setStocks(initialStocks);
+
+    setLoading(true);
+    try {
+      const results = await searchStocks(searchTerm.trim());
+      setStocks(results);
+    } catch {
+      setStocks([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const debouncedSearch = useDebounce(handleSearch, 300);
+
+  useEffect(() => {
+    debouncedSearch();
+  }, [searchTerm, debouncedSearch]);
+
+  const handleSelectStock = () => {
+    setOpen(false);
+    setSearchTerm("");
+    setStocks(initialStocks);
+  };
+
+  return (
+    <>
+      {renderAs === "text" ? (
+        <span onClick={() => setOpen(true)} className="search-text">
+          {label}
+        </span>
+      ) : (
+        <Button onClick={() => setOpen(true)} className="search-btn">
+          {label}
+        </Button>
+      )}
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        className="search-dialog"
+      >
+        <div className="search-field">
+          <CommandInput
+            value={searchTerm}
+            onValueChange={setSearchTerm}
+            placeholder="Search stocks..."
+            className="search-input"
+          />
+          {loading && <Loader2 className="search-loader" />}
+        </div>
+        <CommandList className="search-list">
+          {loading ? (
+            <CommandEmpty className="search-list-empty">
+              Loading stocks...
+            </CommandEmpty>
+          ) : displayStocks?.length === 0 ? (
+            <div className="search-list-indicator">
+              {isSearchMode ? "No results found" : "No stocks available"}
+            </div>
+          ) : (
+            <ul>
+              <div className="search-count">
+                {isSearchMode ? "Search results" : "Popular stocks"}
+                {` `}({displayStocks?.length || 0})
+              </div>
+              {displayStocks?.map((stock, i) => (
+                <li key={stock.symbol} className="search-item">
+                  <Link
+                    href={`/stocks/${stock.symbol}`}
+                    onClick={handleSelectStock}
+                    className="search-item-link"
+                  >
+                    <TrendingUp className="h-4 w-4 text-gray-500" />
+                    <div className="flex-1">
+                      <div className="search-item-name">{stock.name}</div>
+                      <div className="text-sm text-gray-500">
+                        {stock.symbol} | {stock.exchange} | {stock.type}
+                      </div>
+                    </div>
+                    {/*<Star />*/}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/components/SearchCommand.tsx
+++ b/components/SearchCommand.tsx
@@ -67,7 +67,18 @@ export default function SearchCommand({
   return (
     <>
       {renderAs === "text" ? (
-        <span onClick={() => setOpen(true)} className="search-text">
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setOpen(true);
+            }
+          }}
+          className="search-text"
+        >
           {label}
         </span>
       ) : (

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+export function useDebounce(callback: () => void, delay: number) {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  return useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(callback, delay);
+  }, [callback, delay]);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an interactive stock search in the navigation with a command dialog.
  - Opens via button/text trigger and supports Ctrl/Cmd+K.
  - Shows popular stocks by default; debounced typeahead search with loading and empty states.
  - Selectable results navigate to stock details and close the dialog.

- Refactor
  - Header now preloads initial stock data to populate search suggestions before rendering.

- Chores
  - Introduced a reusable debounce hook to power the typeahead behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->